### PR TITLE
Fix for #18

### DIFF
--- a/src/asciidoc/maven.adoc
+++ b/src/asciidoc/maven.adoc
@@ -16,7 +16,7 @@ include::{srcdir}/junit-quick-start/pom.xml[]
 
 First, you need to add the Serenity BDD dependencies to your project. You will typically add `core` and another dependency that correpsonds to the testing library you are using (JUnit in this example). Other supported testing libraries include JBehave and Cucumber.
 
-You typically want the Serenity tests to run as integration tests (that is, during the 'integration-test' phase of the Maven build) rather than as unit tests. You also want the build not to immediately fail when a test fails, but to continue until it has generated the Serenity aggregate reports before failing at the end of the build. To do this, we use the `maven-failsafe-plugin` (3).
+You typically want the Serenity tests to run as integration tests (that is, during the 'integration-test' phase of the Maven build) rather than as unit tests. You also want the build not to immediately fail when a test fails, but to continue until it has generated the Serenity aggregate reports before failing at the end of the build. To do this, we use the `maven-failsafe-plugin` (3). This plugin runs your integration test in the `integration-test` phase without immediately failing the build when a test fails. Build failure is triggered later in the lifecycle, during the `verify` phase.
 
 Normal JUnit tests run from Maven need to start or end with `Test`. But for acceptance tests, a more flexible strategy is better, as it makes it easier to name test cases after scenarios or stories. In the `pom.xml` file shown above, we configure the `maven-failsafe-plugin` to run all of the tests in the `junit` directory, regardless of how they are named (4).
 

--- a/src/samples/junit-quick-start/pom.xml
+++ b/src/samples/junit-quick-start/pom.xml
@@ -61,14 +61,6 @@
                         <surefire.rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</surefire.rerunFailingTestsCount>
                     </systemProperties>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>net.serenity-bdd.maven.plugins</groupId>       <!--5-->


### PR DESCRIPTION
Do not explicitly execute the integration-test and verify phases for
the Failsafe plugin, as this is done by default. This way, reports
will be generated even when the integration test fails.