### PR TITLE
A couple of typos on the remote page documentation. 

### DIFF
--- a/src/asciidoc/remote.adoc
+++ b/src/asciidoc/remote.adoc
@@ -32,7 +32,7 @@ mvn verify -Dwebdriver.remote.url=http://localhost:4444/wd/hub -Dwebdriver.remot
 === Running tests on SauceLabs
 Serenity has special support for running tests on the Cloud-based testing platform http://www.saucelabs.com[SauceLabs]. The general approach is the same as discussed above, but there are a few extra Saucelabs-specific properties:
 
-`saucelabs.url`:: Usually of the form http://<my_id>:<my_API Key>@ondemand.saucelabs.com:80/wd/hu
+`saucelabs.url`:: Usually of the form http://<my_id>:<my_API Key>@ondemand.saucelabs.com:80/wd/hub
 `saucelabs.target.platform`:: See https://saucelabs.com/platforms/
 `saucelabs.driver.version`:: See https://saucelabs.com/platforms/
 `saucelabs.test.name`:: The name of the test as it will appear on the Saucelabs site
@@ -48,7 +48,7 @@ mvn verify -Dsaucelabs.target.platform=XP -Dwebdriver.driver=chrome -Dsaucelabs.
 
 === Running tests on BrowserStack
 
-The setup for running tests on BrowserStack is similar to the one for SauceLabs. The following system properties are availbale:
+The setup for running tests on BrowserStack is similar to the one for SauceLabs. The following system properties are available:
 
 `browserstack.url`:: BrowserStack Hub URL if running the tests on BrowserStack Cloud
 `browserstack.os`::

--- a/src/asciidoc/remote.adoc
+++ b/src/asciidoc/remote.adoc
@@ -7,7 +7,7 @@ In all cases, you tell Serenity to run tests remotely by using the Selenium Remo
 https://code.google.com/p/selenium/wiki/Grid2[Selenium Grid] allows you to run tests on a number of remote machines. It is open source, and relatively easy to set up and configure.
 
 To run your Serenity tests on a Selenium Grid, you need to provide the URL of the Selenium Hub using the `webdriver.remote.url` property. You may also want to provide more information about how and where you want to run your tests, using the following properties:
-`webdriver.remote.driver`:: What driver to use remotely ('firefox','chrome','iexplore' etc.)
+`webdriver.remote.driver`:: What driver to use remotely ('firefox','chrome','iexplorer' etc.)
 `webdriver.remote.browser.version`:: What version of the remote browser to use
 `webdriver.remote.os`:: What operating system the tests should be run on.
 


### PR DESCRIPTION
iexplorer instead of iexplore, /hub instead of /hu, and available instead of avialbale... 