### PR TITLE
Updated manual to include property about restart.browser.each.scenario

### DIFF
--- a/src/asciidoc/jbehave.adoc
+++ b/src/asciidoc/jbehave.adoc
@@ -233,7 +233,7 @@ This archetype creates a project directory structure similar to the one shown he
 
 ==== Running all tests in a single browser window
 
-All web tests can be run in a single browser window using either by setting the `serenity.use.unique.browser` system property or programmatically using runSerenity().inASingleSession() inside the JUnit runner.
+All web tests for one story can be run in a single browser window using either by setting the `restart.browser.each.scenario` system property or programmatically using runSerenity().inASingleSession() inside the JUnit runner. It is default behaving - to run all scenarios in same story in one browser.
 
 [source,java]
 ----

--- a/src/asciidoc/system-props.adoc
+++ b/src/asciidoc/system-props.adoc
@@ -84,7 +84,9 @@ The full list is shown here:
 
 *serenity.batch.number*:: If batch testing is being used, this is the number of the batch being run on this machine.
 
-*serenity.use.unique.browser*:: Set this to run all web tests in a single browser.
+*serenity.use.unique.browser*:: Set this to true for running all web tests in a single browser, for one test. Can be used for configuring Junit and Cucumber, default value is 'false'.
+
+*restart.browser.each.scenario*:: Set this to false for running all web tests in same story file with one browser, can be used when Jbehave is used. default value is 'false'
 
 *serenity.locator.factory*:: Set this property to override the default locator factory with another locator factory (for ex., AjaxElementLocatorFactory or DefaultElementLocatorFactory). By default, Serenity uses a custom locator factory called DisplayedElementLocatorFactory.
 


### PR DESCRIPTION
#### Summary of this PR
Updated manual to include property about restart.browser.each.scenario. 
described different between 
`restart.browser.each.scenario`
and 
`serenity.use.unique.browser`
#### Relevant tickets
#66 , #67 
#### Screenshots (if appropriate)
N/A